### PR TITLE
[変更]内部での更新番号は常にゼロ埋めした文字列に変換して持つ

### DIFF
--- a/GetData.pl
+++ b/GetData.pl
@@ -41,6 +41,7 @@ sub Main{
         print "Error:Unusual ResultNo or GenerateNo\n";
         return;
     }
+    $result_no = sprintf ("%02d", $result_no);
 
     my @objects;        #探索するデータ項目の登録
     my %common_datas;

--- a/UploadParent.pl
+++ b/UploadParent.pl
@@ -41,6 +41,8 @@ sub Main {
         return;
     }
 
+    $result_no = sprintf ("%02d", $result_no);
+
     $upload->DBConnect();
     
     if (ConstData::EXE_DATA) {


### PR DESCRIPTION
・perlコマンドで解析・アップロードを単体で実行する際、ゼロ埋めしていない値を引数にしても実行できるように